### PR TITLE
Renome la clef de stockage du token dans le localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,14 @@ Pour rendre accessible une nouvelle route :
 - créer la route dans [assets/scripts/scripts.js]
 
 
+## Développement
+
+- Forker le repo
+- modifier les settings
+  - donner les droits en écriture a _github action_
+  - pour déployer la branche `online`
+- ajouter votre url (ex: yaf.github.io) dans [Scribouilli/toctoctoc/allowlist.csv](https://github.com/Scribouilli/toctoctoc/blob/main/allowlist.csv)
+
+Voilà à quoi ça peut ressembler :  [github.com/yaf/scribouilli](https://github.com/yaf/scribouilli)
+
+Une fois les développements réalisé, vous pouvez faire une PR dans Scribouilli, en précisant votre url de développement pour que l'on puisse tester la modification.

--- a/assets/scripts/scripts.js
+++ b/assets/scripts/scripts.js
@@ -22,13 +22,14 @@ import Settings from "./components/Settings.svelte";
 
 // @ts-ignore
 window.Buffer = buffer.Buffer;
-const ACCESS_TOKEN_STORAGE_KEY = "access_token"
+const ACCESS_TOKEN_STORAGE_KEY = "scribouilli_access_token"
+const TOCTOCTOC_ACCESS_TOKEN_URL_PARAMETER = "access_token"
 
 // @ts-ignore
 const store = new Store({
   state: {
     // @ts-ignore
-    accessToken: new URL(location).searchParams.get("access_token") || localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY),
+    accessToken: new URL(location).searchParams.get(TOCTOCTOC_ACCESS_TOKEN_URL_PARAMETER) || localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY),
     login: undefined, // Promise<string> | string
     origin: undefined, // Promise<string> | string
     repoName: "test-website-repo-3796",
@@ -119,8 +120,8 @@ function checkRepositoryAvailabilityThen(login, repoName, thenCallback) {
 
 // Store access_token in browser
 const url = new URL(location.href)
-if (url.searchParams.has("access_token")) {
-  url.searchParams.delete("access_token")
+if (url.searchParams.has(TOCTOCTOC_ACCESS_TOKEN_URL_PARAMETER)) {
+  url.searchParams.delete(TOCTOCTOC_ACCESS_TOKEN_URL_PARAMETER)
   history.replaceState(undefined, '', url)
 
   localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, store.state.accessToken)


### PR DESCRIPTION
Cette PR change un label technique : la clef de stockage du token dans le localStorage.

Nous avons également documenté un processus de développement dans le README...

C'est testable sur https://yaf.github.io/scribouilli/ :)
