### PR TITLE
Labellisation textarea - page Settings

### DIFF
--- a/assets/scripts/components/Settings.svelte
+++ b/assets/scripts/components/Settings.svelte
@@ -121,13 +121,13 @@
 
     <div class="wrapper white-zone">
       <h3>Personnalisation du site</h3>
-      <p>
+      <p id="customCSS">
         Pour personnaliser le look de votre site, vous pouvez <a
           href="https://developer.mozilla.org/fr/docs/Learn/Getting_started_with_the_web/CSS_basics"
           >coder en CSS</a
         > ici&nbsp;!
       </p>
-      <textarea cols="20" rows="8" on:change={setTheme}
+      <textarea aria-labelledby="customCSS" cols="20" rows="8" on:change={setTheme}
         >{theme.css || "Chargement du thème personnalisé..."}</textarea
       >
       <button type="button" class="btn btn__medium" on:click={saveTheme}>Enregistrer le CSS</button>


### PR DESCRIPTION
Bonjour, 

Petite PR pour corriger un textarea sans label.

Correction : liaison du texte visible qui précède le champ avec aria-labelledby.

Autres possibilités de correction : 
1. Liaison for/id avec un `<label for="customCSS">CSS personnalisé</label>` positionné hors écran (mais je n'ai pas vu de classe CSS pour ça).
2.  aria-label : `<textarea aria-label="CSS personnalisé" cols="20" rows="8" on:change={setTheme}>`