### PR TITLE
Ajoute le lien pour changer de site dans les paramètres

### DIFF
--- a/assets/scripts/components/screens/Settings.svelte
+++ b/assets/scripts/components/screens/Settings.svelte
@@ -183,7 +183,7 @@
         retrouver ceux que vous avez <strong>déjà créés</strong>.
       </p>
 
-      <a class="btn btn__medium">
+      <a class="btn btn__medium" href="/selectionner-un-site">
         Changer de site
       </a>
     </div>


### PR DESCRIPTION
cf. #29 

Petit oubli du href dans la page des paramètres.