### PR TITLE
Filtre la liste des repos courants pour l'utilisateurice

### DIFF
--- a/assets/scripts/databaseAPI.js
+++ b/assets/scripts/databaseAPI.js
@@ -44,7 +44,7 @@ class DatabaseAPI {
 
   getCurrentUserRepositories() {
     return this.callGithubAPI(
-      `https://api.github.com/user/repos?sort=updated`
+      `https://api.github.com/user/repos?sort=updated&affiliation=owner&visibility=public`
     ).then((response) => {
       return response.json();
     });


### PR DESCRIPTION
## Description

En attendant de pouvoir utiliser les repos des organisations, je filtre la liste des repos courants pour n'avoir que les repos publics du user GitHub connecté.e