### PR TITLE
Fix la récuperation du login s'il n'y a qu'un seul repo

### DIFF
--- a/assets/scripts/routes/welcome.js
+++ b/assets/scripts/routes/welcome.js
@@ -21,7 +21,7 @@ export default () => {
       .then((repos) => {
         if (repos.length === 1) {
             const repoName = repos[0].name;
-            const account = repos[0].owner;
+            const account = repos[0].owner.login;
 
             page(`/atelier-list-pages?repoName=${repoName}&account=${account}`);
         } else {


### PR DESCRIPTION
cf. #29 

## Description

Lorsque l'utilisateurice authentifié.e n'a qu'un seul repo, on redirige automatiquement sur l'atelier de ce repo. Cette PR fixe la récupération du login pour ce repo.