### PR TITLE
Répare la création de nouvelle page

### DIFF
--- a/assets/scripts/routes/atelier-pages.js
+++ b/assets/scripts/routes/atelier-pages.js
@@ -155,7 +155,7 @@ export default ({ querystring }) => {
 
       Promise.resolve(state.login).then((login) => {
         databaseAPI
-          .writeFile(login, state.currentRepository.name, fileName, finalContent, message)
+          .writeFile(login, state.currentRepository.name, newFileName, finalContent, message)
           .then(() => {
             state.buildStatus.setBuildingAndCheckStatusLater();
             page(`/atelier-list-pages?repoName=${currentRepository.name}&account=${currentRepository.owner}`);


### PR DESCRIPTION
## Description.

Actuellement, on ne peut pas créer de nouvelle page en production. En console, on a l'erreur JS suivante : 
```
Uncaught (in promise) TypeError: path must not be empty
```

J'ai fait ce petit fix mais je ne peux pas tester car je suis bloquée avec https://github.com/Scribouilli/scribouilli/issues/49.