### PR TITLE
Contraint les iframes à ne pas dépasser la largeur de l'écran

### DIFF
--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -60,6 +60,7 @@ button {
 /* default iframe borders are just ugly */
 iframe {
   border: 0;
+  max-width: 100%;
 }
 
 * {


### PR DESCRIPTION
Idéalement, il faut appliquer un attribut `style="aspect-ratio: <width>/<height>;"` dans l'`iframe`.