### PR TITLE
Permet de voir un aperçu du contenu markdown

### DIFF
--- a/assets/scripts/components/screens/intern/Editeur.svelte
+++ b/assets/scripts/components/screens/intern/Editeur.svelte
@@ -10,6 +10,7 @@
   export let currentRepository
 
   import { createEventDispatcher } from 'svelte'
+  import marked from 'marked';
   import Skeleton from '../../Skeleton.svelte'
   import { makeFileNameFromTitle } from '../../../utils'
   import databaseAPI from '../../../databaseAPI'
@@ -18,6 +19,8 @@
 
   let image
   let imageMd = ''
+
+  let preview = 'dsds';
 
   let file = {
     fileName: '',
@@ -98,6 +101,16 @@
       imageMd = `![Texte décrivant l'image](/images/${img.name})`
     }
   }
+
+  $: {
+    try {
+
+      preview = marked.parse(file.content);
+    } catch (e) {
+      preview = 'Il y a une erreur dans le Markdown. Veuillez vérifier votre syntaxe.';
+    }
+  }
+
 </script>
 
 <Skeleton {currentRepository} {buildStatus} {showArticles}>
@@ -186,6 +199,12 @@
               rows="10"
             />
           </div>
+          {#if preview}
+            <div class="preview">
+              <h4>Aperçu</h4>
+              <div>{@html preview}</div>
+            </div>
+          {/if}
           <div class="actions-zone">
             <a href={listPrefix} class="btn__retour" on:click={onBackClick}
               >Retour</a
@@ -258,6 +277,11 @@
 
   .content {
     margin-top: 2rem;
+  }
+  .preview > div {
+    margin: 0.5em 0;
+    padding: 0.5em;
+    background-color: white;
   }
 
   .actions-zone {

--- a/assets/scripts/components/screens/intern/Editeur.svelte
+++ b/assets/scripts/components/screens/intern/Editeur.svelte
@@ -10,7 +10,8 @@
   export let currentRepository
 
   import { createEventDispatcher } from 'svelte'
-  import marked from 'marked';
+  import marked from 'marked'
+  import * as DOMPurify from 'dompurify'
   import Skeleton from '../../Skeleton.svelte'
   import { makeFileNameFromTitle } from '../../../utils'
   import databaseAPI from '../../../databaseAPI'
@@ -20,7 +21,7 @@
   let image
   let imageMd = ''
 
-  let preview = 'dsds';
+  let preview = ''
 
   let file = {
     fileName: '',
@@ -104,13 +105,13 @@
 
   $: {
     try {
-
-      preview = marked.parse(file.content);
+      const html = marked.parse(file.content)
+      preview = DOMPurify.sanitize(html)
     } catch (e) {
-      preview = 'Il y a une erreur dans le Markdown. Veuillez vérifier votre syntaxe.';
+      preview =
+        'Il y a une erreur dans le Markdown. Veuillez vérifier votre syntaxe.'
     }
   }
-
 </script>
 
 <Skeleton {currentRepository} {buildStatus} {showArticles}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "baredux": "github:DavidBruant/baredux",
         "d3-fetch": "^3.0.1",
         "date-fns": "^2.30.0",
+        "dompurify": "^3.0.5",
         "front-matter": "^4.0.2",
         "isomorphic-git": "^1.24.2",
         "marked": "^5.1.2",
@@ -729,6 +730,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
       "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g=="
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A=="
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -4478,6 +4484,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
       "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g=="
+    },
+    "dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A=="
     },
     "eastasianwidth": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "date-fns": "^2.30.0",
         "front-matter": "^4.0.2",
         "isomorphic-git": "^1.24.2",
+        "marked": "^5.1.2",
         "page": "^1.11.6"
       },
       "devDependencies": {
@@ -2183,6 +2184,17 @@
       "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "node_modules/marked": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/memorystream": {
@@ -5526,6 +5538,11 @@
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
+    },
+    "marked": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg=="
     },
     "memorystream": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "date-fns": "^2.30.0",
     "front-matter": "^4.0.2",
     "isomorphic-git": "^1.24.2",
+    "marked": "^5.1.2",
     "page": "^1.11.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "baredux": "github:DavidBruant/baredux",
     "d3-fetch": "^3.0.1",
     "date-fns": "^2.30.0",
+    "dompurify": "^3.0.5",
     "front-matter": "^4.0.2",
     "isomorphic-git": "^1.24.2",
     "marked": "^5.1.2",


### PR DESCRIPTION
Cette PR ajoute un aperçu du contenu saisi en markdown par l'utilisateur dans la textarea de la page de l'éditeur.
L'aperçu est rafraîchi automatiquement dès que le contenu est modifié.
Je pense que cela peut aider les gens qui ne connaissent pas bien la syntaxe markdown.

Du côté UX, j'ai choisi de le faire très simplement, l'aperçu s'affiche en dessous de la textarea.
On pourrait faire des onglets (un onglet avec la textarea et un onglet avec l'aperçu, on voit ça souvent, dans GitHub par exemple), mais j'ai l'impression que la ligne UX suivi dans Scribouilli privilégie une approche la plus simple possible, d'où mon choix. Si toutefois vous préférez des onglets, je peux le faire :)

Et sinon, j'adore votre idée, bravo !!