### PR TITLE
Ordre des pages nouvelle version

### DIFF
--- a/assets/scripts/routes/atelier-pages.js
+++ b/assets/scripts/routes/atelier-pages.js
@@ -33,9 +33,7 @@ const makeMapStateToProps = fileName => state => {
           content: markdownContent,
           previousContent: markdownContent,
           title: data?.title,
-          index:
-            data?.order ??
-            store.state.pages.findIndex(p => p.path == fileName) + 1,
+          index: data?.order,
           previousTitle: data?.title,
         }
       } catch (errorMessage) {

--- a/assets/scripts/utils.js
+++ b/assets/scripts/utils.js
@@ -98,10 +98,17 @@ export function makeArticleFileName(title, date) {
 export function makeFrontMatterYAMLJsaisPasQuoiLa(
   title,
   pages = false,
-  index = 1,
+  index = null,
 ) {
   if (pages) {
-    console.log('index : ', index)
+    //s'il n'y a pas d'order, on n'en rajoute pas automatiquement
+    if (index === null || index === undefined) {
+      return [
+        '---',
+        'title: ' + '"' + title.replace(/"/g, '\\"') + '"',
+        '---',
+      ].join('\n')
+    }
     return [
       '---',
       'title: ' + '"' + title.replace(/"/g, '\\"') + '"',


### PR DESCRIPTION
Toujours l'ordre des pages, mais avec quelques trucs mieux fait, notamment pas de changement automatique d'order dans les pages et la gestion de l'ordre pour les nouvelles pages