### PR TITLE
Pousse le nouveau fichier ET la suppression en même temps

### DIFF
--- a/assets/scripts/databaseAPI.js
+++ b/assets/scripts/databaseAPI.js
@@ -345,7 +345,7 @@ class DatabaseAPI {
     await this.cloneIfNeeded(login, repoName)
 
     if (typeof fileName !== 'string') {
-      await this.deleteFile(login, repoName, fileName.old)
+      await this.deleteFile(login, repoName, fileName.old, false)
       fileName = fileName.new
     }
 


### PR DESCRIPTION
closes #99 

Il y a un pépin lorsque l'on change le titre :
- d'abord, on supprime l'existant (parce qu'on ne sait pas le renommer avec l'API git)
- puis, on ajoute le nouveau (avec son contenu)

Le hic, c'est que lorsque l'on supprime, on enchaine avec un push, ça perturbe l'arbre git courant. 

Cette PR propose de mettre le paramètre `push` a `false` pour enchainer la suppression et l'ajout avant le push.