### PR TITLE
Répare le CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
           npm pkg delete scripts.prepare
-          npm ci --omit=dev
+          npm ci
           npm run build
 
       - name: Add and commit


### PR DESCRIPTION
## Description 

Suite à #106, j'ai changé la commande `npm install` en `npm ci --omit=dev`. Il se trouve que nous avons besoin des dépendances de développement pour builder l'application. Je retire donc le flag sur cette PR.