### PR TITLE
Répare le build dans le CI/CD

### DIFF
--- a/assets/scripts/components/screens/AfterGithubLogin.svelte
+++ b/assets/scripts/components/screens/AfterGithubLogin.svelte
@@ -1,7 +1,7 @@
 <script>
   import Skeleton from "./../Skeleton.svelte";
   import SiteCreationLoader from "./../loaders/SiteCreationLoader.svelte";
-  import '../../../types.js'
+  import './../../types.js'
 
   /** @type {Promise<GithubRepository[]|Void>} */
   export let currentUserReposP;

--- a/assets/scripts/components/screens/ArticleContenu.svelte
+++ b/assets/scripts/components/screens/ArticleContenu.svelte
@@ -1,6 +1,6 @@
 <script>
   import {makeAtelierListArticlesURL} from '../../routes/atelier-list-articles.js'
-  import '../../../types.js'
+  import './../../types.js'
 
   /** @type {Promise<EditeurFile>} */
   export let fileP;

--- a/assets/scripts/components/screens/PageContenu.svelte
+++ b/assets/scripts/components/screens/PageContenu.svelte
@@ -1,6 +1,6 @@
 <script>
   import {makeAtelierListPageURL} from '../../routes/atelier-list-pages.js'
-  import '../../../types.js'
+  import './../../types.js'
 
   /** @type {Promise<EditeurFile>} */
   export let fileP;

--- a/assets/scripts/components/screens/Settings.svelte
+++ b/assets/scripts/components/screens/Settings.svelte
@@ -3,7 +3,7 @@
 
   import Skeleton from '../Skeleton.svelte'
   import { createEventDispatcher } from 'svelte'
-  import '../../../types.js'
+  import './../../types.js'
 
   const dispatch = createEventDispatcher()
   $: enabled = false

--- a/assets/scripts/components/screens/intern/ListContenu.svelte
+++ b/assets/scripts/components/screens/intern/ListContenu.svelte
@@ -3,7 +3,7 @@
   import store from '../../../store'
   import Skeleton from '../../Skeleton.svelte'
   import { makePageFrontMatter } from '../../../utils'
-  import '../../../../types.js'
+  import './../../../types.js'
 
   /** @type any */
   export let buildStatus

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@rollup/plugin-node-resolve": "^8.0.0",
         "@rollup/plugin-terser": "^0.4.4",
         "@types/dompurify": "^3.0.4",
-        "@types/marked": "^6.0.0",
         "@types/page": "^1.11.8",
         "http-server": "^14.1.1",
         "husky": "^8.0.3",
@@ -269,16 +268,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
-    },
-    "node_modules/@types/marked": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-6.0.0.tgz",
-      "integrity": "sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA==",
-      "deprecated": "This is a stub types definition. marked provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "marked": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "17.0.8",
@@ -4122,15 +4111,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
-    },
-    "@types/marked": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-6.0.0.tgz",
-      "integrity": "sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA==",
-      "dev": true,
-      "requires": {
-        "marked": "*"
-      }
     },
     "@types/node": {
       "version": "17.0.8",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@types/dompurify": "^3.0.4",
-    "@types/marked": "^6.0.0",
     "@types/page": "^1.11.8",
     "http-server": "^14.1.1",
     "husky": "^8.0.3",


### PR DESCRIPTION
## Description

Suite à #106, j'ai fait des imports avec des chemins relatifs. Pour que Rollup puisse fonctionner correctement, j'ai corrigé ces chemins.

Par ailleurs, j'ai également retiré un package inutile qui servaient pour les types de la lib `marked`.