### PR TITLE
Répare la création d'article

### DIFF
--- a/assets/scripts/actions/article.js
+++ b/assets/scripts/actions/article.js
@@ -31,12 +31,12 @@ export const deleteArticle = fileName => {
 }
 
 /**
- * @param {string} content
  * @param {string} title
+ * @param {string} content
  *
  * @returns {Promise<void>}
  */
-export const createArticle = (content, title) => {
+export const createArticle = (title, content) => {
   const { state } = store
 
   const date = new Date()


### PR DESCRIPTION
closes #116 

## Description

Actuellement, en production, lorsqu'on crée un article de blog, on envoie le contenu en tant que titre au repo git. Cette PR corrige ce bug.