### PR TITLE
Retirer les features settings d'un repo uniquement à la création d'un site

### DIFF
--- a/assets/scripts/actions.js
+++ b/assets/scripts/actions.js
@@ -146,7 +146,7 @@ export const getCurrentRepoArticles = () => {
  * @returns {Promise<any>}
  */
 export const setupRepo = (owner, repo) =>
-  getOAuthServiceAPI().setupRepository(owner, repo)
+  getOAuthServiceAPI().addTopicOnRepository(owner, repo)
 
 /**
  * @summary Set the current repository from the owner and the name

--- a/assets/scripts/actions.js
+++ b/assets/scripts/actions.js
@@ -140,15 +140,6 @@ export const getCurrentRepoArticles = () => {
 }
 
 /**
- *
- * @param {string} owner
- * @param {string} repo
- * @returns {Promise<any>}
- */
-export const setupRepo = (owner, repo) =>
-  getOAuthServiceAPI().addTopicOnRepository(owner, repo)
-
-/**
  * @summary Set the current repository from the owner and the name
  * of the repository in the URL
  *

--- a/assets/scripts/components/screens/SelectCurrentSite.svelte
+++ b/assets/scripts/components/screens/SelectCurrentSite.svelte
@@ -4,7 +4,7 @@
 
   import Skeleton from "./../Skeleton.svelte";
   import Loader from "./../loaders/Loader.svelte";
-  import { setupRepo } from "../../actions";
+  import { getOAuthServiceAPI } from "../../oauth-services-api/index.js";
 
   /** @type {string | Promise<string> | undefined} */
   export let currentAccount
@@ -33,7 +33,10 @@
 
     loading = true;
 
-    setupRepo(repo.owner.login, repo.name);
+    // On devrait pouvoir retirer cette ligne à un moment. Elle sert pour
+    // tagguer tous les repos Scribouilli qui n'ont pas encore de topic
+    // (c'est-à-dire tous les repos créés au tout tout début)
+    getOAuthServiceAPI().addTopicOnRepository(repo.owner.login, repo.name);
     page(`/atelier-list-pages?repoName=${repo.name}&account=${repo.owner.login}`);
 
     loading = false;

--- a/assets/scripts/oauth-services-api/github.js
+++ b/assets/scripts/oauth-services-api/github.js
@@ -79,17 +79,19 @@ export class GitHubAPI {
           description: 'Mon site Scribouilli',
         }),
       },
-    ).then(response => {
-      // We don't wait for the end of the setup to return the response
-      // because we don't need all the data it returns.
-      this.setupRepository(account, repositoryName)
+    )
+      .then(response => this.addTopicOnRepository(account, repositoryName))
+      .then(response => {
+        this.updateRepositoryFeaturesSettings(account, repositoryName)
 
-      return response
-    })
+        // We don't wait for the end of the setup to return the response
+        // because we don't need all the data it returns.
+        return response
+      })
   }
 
-  /** @type {OAuthServiceAPI["setupRepository"]} */
-  setupRepository(account, repositoryName) {
+  /** @type {OAuthServiceAPI["addTopicOnRepository"]} */
+  addTopicOnRepository(account, repositoryName) {
     return this.callAPI(
       `${gitHubApiBaseUrl}/repos/${account}/${repositoryName}/topics`,
       {
@@ -104,24 +106,27 @@ export class GitHubAPI {
           names: ['site-scribouilli'],
         }),
       },
-    ).then(response => {
-      return this.callAPI(
-        `${gitHubApiBaseUrl}/repos/${account}/${repositoryName}`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: 'token ' + this.accessToken,
-            Accept: 'application/vnd.github+json',
-          },
-          body: JSON.stringify({
-            homepage: `https://${account.toLowerCase()}.github.io/${repositoryName.toLowerCase()}`,
-            has_issues: false,
-            has_projects: false,
-            has_wiki: false,
-          }),
+    )
+  }
+
+  /** @type {OAuthServiceAPI["updateRepositoryFeaturesSettings"]} */
+  updateRepositoryFeaturesSettings(account, repositoryName) {
+    return this.callAPI(
+      `${gitHubApiBaseUrl}/repos/${account}/${repositoryName}`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'token ' + this.accessToken,
+          Accept: 'application/vnd.github+json',
         },
-      )
-    })
+        body: JSON.stringify({
+          homepage: `https://${account.toLowerCase()}.github.io/${repositoryName.toLowerCase()}`,
+          has_issues: false,
+          has_projects: false,
+          has_wiki: false,
+        }),
+      },
+    )
   }
 
   /** @type {OAuthServiceAPI["deleteRepository"]} */

--- a/assets/scripts/types.js
+++ b/assets/scripts/types.js
@@ -12,7 +12,8 @@
  * @property {(account: string, repositoryName: string) => Promise<GithubRepository>} getRepository
  * @property {() => Promise<GithubRepository[]>} getCurrentUserRepositories
  * @property {(account: string, repositoryName: string) => Promise<any>} createDefaultRepository
- * @property {(account: string, repositoryName: string) => Promise<any>} setupRepository
+ * @property {(account: string, repositoryName: string) => Promise<any>} addTopicOnRepository
+ * @property {(account: string, repositoryName: string) => Promise<any>} updateRepositoryFeaturesSettings
  * @property {(account: string, repositoryName: string) => Promise<any>} deleteRepository
  * @property {(account: string, repositoryName: string) => Promise<any>} createPagesWebsiteFromRepository
  * @property {(account: string, repositoryName: string) => Promise<any>} getPagesWebsite


### PR DESCRIPTION
close #93 

## Description

Cette PR sépare l'ajout d'un topic et la gestion des features settings (choix d'avoir un wiki ou non, des issues, etc.) sur un repo afin de retirer ces features settings uniquement lorsqu'on crée un nouveau site Scribouilli et pas lorsqu'on modifie un site existant.