### PR TITLE
Utiliser les GitHub Actions à la place de l'option Pages pour de déploiement sur GitHub

### DIFF
--- a/assets/scripts/buildStatus.js
+++ b/assets/scripts/buildStatus.js
@@ -53,7 +53,11 @@ export default function (owner, repoName) {
               'buildStatus.checkStatus',
             )
 
-            repoStatus = status
+            if (['in_progress', 'success', 'error'].includes(status)) {
+              repoStatus = status
+            } else {
+              repoStatus = 'in_progress'
+            }
 
             if (reaction) {
               reaction(repoStatus)

--- a/assets/scripts/buildStatus.js
+++ b/assets/scripts/buildStatus.js
@@ -3,59 +3,8 @@
 import { getOAuthServiceAPI } from './oauth-services-api/index.js'
 import { logMessage } from './utils.js'
 
-/*
-
-Pas d'étoile
-
-
-Tant que le répo ne déploi pas, le status vaut `null`
-Quand un build est annulé par un nouveau commit,
-
-l'API de statut retourne d'abord une erreur et plus tard, `building` puis `built`
-
-Quand on viens de commité et qu'on interroge l'API `/pages`
-elle nous réponds d'abord que c'est built (parce que le nouveau build n'a pas commencé).
-
-https://docs.github.com/en/rest/pages?apiVersion=2022-11-28#get-a-github-pages-site
-
-Peut-être que l'on pourrait changer de stratégie et utiliser
-`await octokit.request('GET /repos/{owner}/{repo}/deployments'` avec un 1 per_page
-
-Puis, récupérer
-
-"statuses_url": "https://api.github.com/repos/octocat/example/deployments/1/statuses",
-pour ensuite faire du polling dessus, et récupérer la propriété state
-
-    "state": {
-        "description": "The state of the status.",
-        "enum": [
-          "error",
-          "failure",
-          "inactive",
-          "pending",
-          "success",
-          "queued",
-          "in_progress"
-        ]
-    }
-
-
-
-NOTE
-
-Nous pensons que GitHub laisse mourrir l'API GitHub Pages
-
-Un refactoring à faire plus tard serait d'utilise les API de déploiement qui sont plus riche en information.
-
-Nous pourirons essayer de suivre un commit pour s'assurer que nous allons à la fin du déploiement.
-
-Voir `databaseAPI.getLastDeployment(login, repoName)` et `databaseAPI.getDeploymentStatus(deployment)`
-
-
-*/
-
 /**
- * @typedef {"building" | "built" | "errored"} BuildStatus
+ * @typedef {"in_progress" | "success" | "error"} BuildStatus
  */
 
 /**
@@ -66,7 +15,7 @@ Voir `databaseAPI.getLastDeployment(login, repoName)` et `databaseAPI.getDeploym
  */
 export default function (owner, repoName) {
   /** @type {BuildStatus} */
-  let repoStatus = 'building'
+  let repoStatus = 'in_progress'
   /** @type {(status: BuildStatus) => any} */
   let reaction
   /** @type {ReturnType<setTimeout> | undefined} */
@@ -96,31 +45,26 @@ export default function (owner, repoName) {
     checkStatus() {
       return (
         getOAuthServiceAPI()
-          .getPagesWebsite(owner, repoName)
+          .getPagesWebsiteDeploymentStatus(owner, repoName)
           // @ts-ignore
-          .then(({ status }) => {
+          .then(status => {
             logMessage(
-              `GitHub Pages status is ${status}`,
+              `GitHub deployment's status is ${status}`,
               'buildStatus.checkStatus',
             )
 
-            if (['built', 'errored', 'building'].includes(status)) {
-              repoStatus = status
-            } else {
-              // status === null
-              repoStatus = 'building'
-            }
+            repoStatus = status
 
             if (reaction) {
               reaction(repoStatus)
             }
 
-            if (repoStatus === 'building') {
+            if (repoStatus === 'in_progress') {
               scheduleCheck()
             }
           })
           .catch(() => {
-            repoStatus = 'errored'
+            repoStatus = 'error'
             if (reaction) {
               reaction(repoStatus)
             }
@@ -128,7 +72,7 @@ export default function (owner, repoName) {
       )
     },
     setBuildingAndCheckStatusLater(t = 30000) {
-      repoStatus = 'building'
+      repoStatus = 'in_progress'
       // @ts-ignore
       clearTimeout(timeout)
       timeout = undefined

--- a/assets/scripts/components/Header.svelte
+++ b/assets/scripts/components/Header.svelte
@@ -117,15 +117,15 @@
     margin-top: 0.3rem;
   }
 
-  .build-building::after {
+  .build-in_progress::after {
     content: '🕰 En cours de publication (2-3 min)';
   }
 
-  .build-built::after {
+  .build-success::after {
     content: '✅ Site à jour';
   }
 
-  .build-errored::after {
+  .build-error::after {
     content: '🕰 En cours de publication (15 min max)';
   }
 </style>

--- a/assets/scripts/oauth-services-api/github.js
+++ b/assets/scripts/oauth-services-api/github.js
@@ -150,7 +150,9 @@ export class GitHubAPI {
           Accept: 'applicatikn/vnd.github+json',
         },
         method: 'POST',
-        body: JSON.stringify({ source: { branch: 'main' } }),
+        body: JSON.stringify({
+          build_type: 'workflow',
+        }),
       },
     )
   }

--- a/assets/scripts/oauth-services-api/github.js
+++ b/assets/scripts/oauth-services-api/github.js
@@ -157,20 +157,32 @@ export class GitHubAPI {
     )
   }
 
-  /** @type {OAuthServiceAPI["getPagesWebsite"]} */
-  getPagesWebsite(account, repositoryName) {
+  /** @type {OAuthServiceAPI["getPagesWebsiteDeploymentStatus"]} */
+  getPagesWebsiteDeploymentStatus(account, repositoryName) {
+    // TODO: We need to add the `sha` parameter to avoid the GitHub API to return
+    // cached data.
     return this.callAPI(
-      `${gitHubApiBaseUrl}/repos/${account}/${repositoryName}/pages`,
-    ).then(response => {
-      return response.json()
-    })
+      `${gitHubApiBaseUrl}/repos/${account}/${repositoryName}/deployments?environment=github-pages`,
+    )
+      .then(response => response.json())
+      .then(json => {
+        console.debug('Deployments list: ', json)
+        const statusesUrl = json[0].statuses_url
+
+        return this.callAPI(`${statusesUrl}?per_page=1`)
+      })
+      .then(response => response.json())
+      .then(json => {
+        console.debug('Deployment status: ', json[0].state)
+        return json[0].state
+      })
   }
 
   /** @type {OAuthServiceAPI["isPagesWebsiteBuilt"]} */
   isPagesWebsiteBuilt(account, repositoryName) {
-    return this.getPagesWebsite(account, repositoryName)
+    return this.getPagesWebsiteDeploymentStatus(account, repositoryName)
       .then(response => {
-        return response.status === 'built'
+        return response === 'success'
       })
       .catch(error => {
         return false

--- a/assets/scripts/types.js
+++ b/assets/scripts/types.js
@@ -16,7 +16,7 @@
  * @property {(account: string, repositoryName: string) => Promise<any>} updateRepositoryFeaturesSettings
  * @property {(account: string, repositoryName: string) => Promise<any>} deleteRepository
  * @property {(account: string, repositoryName: string) => Promise<any>} createPagesWebsiteFromRepository
- * @property {(account: string, repositoryName: string) => Promise<any>} getPagesWebsite
+ * @property {(account: string, repositoryName: string) => Promise<any>} getPagesWebsiteDeploymentStatus
  * @property {(account: string, repositoryName: string) => Promise<boolean>} isPagesWebsiteBuilt
  * @property {(account: string, repositoryName: string) => Promise<boolean>} isRepositoryReady
  */


### PR DESCRIPTION
Lié à https://github.com/Scribouilli/site-template/pull/2

## Description

Cette PR change le call (`/owner/repo/pages`) qui active les GitHub Pages pour le déploiement sur GitHub. Jusque là, on utilise l'option `Pages` dans laquelle on indique la branche à déployer. Avec cette PR, on va utiliser les GitHub Actions qui seront définies dans le [`site-template`](https://github.com/Scribouilli/site-template/pull/2).

## Rétro-compatibilité

Avec ce changement, le call `/owner/repo/pages` via les actions ne permet plus de récupérer le `status` du déploiement. Il retourne `null` dès qu'on utilise les actions.

J'ai donc ajouté la gestion du statut du build avec l'[API des déploiements](https://docs.github.com/fr/rest/deployments/deployments?apiVersion=2022-11-28). Ça permet de récupérer le statut du déploiement dans l'environnement `github-pages` qu'on soit passé par l'ancien call ou le nouveau call.