### PR TITLE
Redirige sur la page creer-un-nouveau-site quand l'utilisateurice n'a aucun repo

### DIFF
--- a/assets/scripts/components/Header.svelte
+++ b/assets/scripts/components/Header.svelte
@@ -65,31 +65,33 @@
 </script>
 
 <header>
-  {#await publishedWebsiteURL}
-    <div>
-      <p>
-        (Chargement en cours…)
-      </p>
-      {#if buildStatusClass}
-        <p class={buildStatusClass} />
-      {/if}
-    </div>
-  {:then publishedURL}
-    <div>
-      <p>
-        <a
-          href="{publishedURL}"
-          class="project-name"
-          target="_blank"
-        >
-          {publishedURL}
-        </a>
-      </p>
-      {#if buildStatusClass}
-        <p class={buildStatusClass} />
-      {/if}
-    </div>
-  {/await}
+  {#if currentRepository}
+    {#await publishedWebsiteURL}
+      <div>
+        <p>
+          (Chargement en cours…)
+        </p>
+        {#if buildStatusClass}
+          <p class={buildStatusClass} />
+        {/if}
+      </div>
+    {:then publishedURL}
+      <div>
+        <p>
+          <a
+            href="{publishedURL}"
+            class="project-name"
+            target="_blank"
+          >
+            {publishedURL}
+          </a>
+        </p>
+        {#if buildStatusClass}
+          <p class={buildStatusClass} />
+        {/if}
+      </div>
+    {/await}
+  {/if}
 
   <h1>
     <a href={homeURL} class="go-home"

--- a/assets/scripts/routes/after-oauth-login.js
+++ b/assets/scripts/routes/after-oauth-login.js
@@ -74,8 +74,6 @@ export default () => {
   if (type === 'github' || type === 'gitlab') {
     currentUserReposP = fetchCurrentUserRepositories().then(repos => {
       if (repos.length === 0) {
-        // If the user has no repository, we automatically create one for them.
-
         page.redirect('/creer-un-nouveau-site')
       } else {
         store.mutations.setReposForAccount({

--- a/assets/scripts/routes/after-oauth-login.js
+++ b/assets/scripts/routes/after-oauth-login.js
@@ -33,11 +33,10 @@ const storeOAuthProviderAccess = () => {
 
   let origin = url.searchParams.get(TOCTOCTOC_OAUTH_PROVIDER_ORIGIN_PARAMETER)
 
-  if(!origin){
+  if (!origin) {
     if (providerName === 'github') {
       origin = 'https://github.com'
-    }
-    else{
+    } else {
       throw new TypeError('missing origin')
     }
   }
@@ -76,10 +75,8 @@ export default () => {
     currentUserReposP = fetchCurrentUserRepositories().then(repos => {
       if (repos.length === 0) {
         // If the user has no repository, we automatically create one for them.
-        createRepositoryForCurrentAccount(
-          defaultRepositoryName,
-          templates.default,
-        )
+
+        page.redirect('/creer-un-nouveau-site')
       } else {
         store.mutations.setReposForAccount({
           login: store.state.login,


### PR DESCRIPTION
## Description

Jusque là, lorsqu'un.e utilisateurice n'avait pas de repo, on lui créait automatiquement un petit site avec [`site-template`](https://github.com/Scribouilli/site-template) qui contient le thème de Mimoza. Depuis qu'on a introduit la possibilité de choisir quel genre de site on veut créer (cf. https://github.com/Scribouilli/scribouilli/pull/142), ce serait mieux de laisser le choix à l'utilisateurice de quel genre de site iel veut créer plutôt que de créer un site automatiquement. En plus, ça lui permet de choisir le nom de son site dès le début.

Cette PR permet de faire cette redirection. J'y fixe également un mini-bug d'affichage sur le header.