### PR TITLE
clarifie message chargement

### DIFF
--- a/assets/scripts/components/Header.svelte
+++ b/assets/scripts/components/Header.svelte
@@ -69,7 +69,7 @@
     {#await publishedWebsiteURL}
       <div>
         <p>
-          (Chargement en cours…)
+          (L'adresse du site va apparaître ici…)
         </p>
         {#if buildStatusClass}
           <p class={buildStatusClass} />


### PR DESCRIPTION
Avant, l'url apparaissait immédiatement, et les personnes la voyaient une fois et savaient où elle se trouvait.

Maintenant, elle met beaucoup + de temps à apparaitre et se recharge à chaque changement de page, donc les utilisateurs la cherchent beaucoup (et changent de page, donc elle n'apparait pas…)

Pour pallier à ce problème je rend explicite que ce qui charge en haut à gauche, c'est l'url du site.

Peut-être à terme ça pourrait ne pas recharger à chaque clic ou autre solution ?