### PR TITLE
Ajout de style dans la preview de l'éditeur pour les mini-sites Framalibre

### DIFF
--- a/assets/scripts/components/screens/intern/Editeur.svelte
+++ b/assets/scripts/components/screens/intern/Editeur.svelte
@@ -33,6 +33,7 @@
   import { makeFileNameFromTitle } from '../../../utils'
   import store from '../../../store'
   import { writeFileAndCommit } from '../../../actions/file'
+  import './../../../../styles/editeur-preview/framalibre.css'
 
   /** @type {FileList} */
   let image

--- a/assets/styles/editeur-preview/framalibre.css
+++ b/assets/styles/editeur-preview/framalibre.css
@@ -1,0 +1,59 @@
+.framalibre-notice {
+  display: flex;
+  background-color: white;
+  border: 1px solid rgba(0, 0, 0, 0.125);
+  border-radius: 0.25rem;
+}
+
+.framalibre-notice:not(:last-child) {
+  margin-bottom: 3rem;
+}
+
+.framalibre-notice > div {
+  padding: 1.25rem;
+}
+
+.framalibre-notice > div:first-of-type {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 0 0 25%;
+}
+
+.framalibre-notice img {
+  max-width: 70%;
+}
+
+.framalibre-notice > div:last-of-type > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.framalibre-notice a {
+  display: inline-block;
+  padding: 0.375rem 0.75rem;
+  font-weight: 400;
+  color: #cc4e13;
+  text-align: center;
+  vertical-align: middle;
+  font-size: 1rem;
+  line-height: 1.5;
+  text-decoration: none;
+  border: 1px solid #cc4e13;
+  background-color: transparent;
+  border-radius: 0.25rem;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+.framalibre-notice a:hover {
+  color: #fff;
+  background-color: #cc4e13;
+  border-color: #cc4e13;
+}
+
+@media (max-width: 768px) {
+  .framalibre-notice {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
Closes #162 

## Description

Cette PR permet d'avoir la CSS pour afficher correctement les encarts des logiciels libres pour les mini-sites Framalibre. Pour l'instant, j'ai juste ajouté une feuille de style qui reprend les [styles de Kabusin](https://github.com/Scribouilli/kabusin/blob/main/assets/style/framalibre-notice.css).

Je me dis qu'on pourrait aussi ajouter une commande qui copie ce fichier au build, comme ça, on serait à jour lorsque le thème est mis à jour. Je n'ai pas creusé cette piste.

## Aperçu

![Screenshot 2023-12-18 at 14-31-50 Scribouilli](https://github.com/Scribouilli/scribouilli/assets/548778/90108c9f-7f58-4f4c-91ea-e0b8743f24e7)
