### PR TITLE
:recycle: Corrige l'execution des tests

### DIFF
--- a/assets/scripts/actions/current-repository.js
+++ b/assets/scripts/actions/current-repository.js
@@ -12,7 +12,7 @@ import GitAgent from '../GitAgent.js'
 import { handleErrors, logMessage } from './../utils.js'
 import { fetchAuthenticatedUserLogin } from './current-user.js'
 import makeBuildStatus from './../buildStatus.js'
-import { writeFileAndCommit, writeFileAndPushChanges } from './file.js'
+import { file } from './file.js'
 import { getPagesList } from './page.js'
 import { getArticlesList } from './article.js'
 import { getOAuthServiceAPI } from '../oauth-services-api/index.js'
@@ -165,7 +165,7 @@ export const setBaseUrlInConfigIfNecessary = async baseUrl => {
     const configYmlContent = yaml.dump(config)
 
     console.log('configYmlContent', configYmlContent)
-    return writeFileAndPushChanges(
+    return file.writeFileAndPushChanges(
       '_config.yml',
       configYmlContent,
       'Mise à jour de `baseurl` dans la config',
@@ -203,7 +203,11 @@ export async function installPluginIfNecessary(plugin, version) {
       `  gem "${plugin}", "~> ${version}"\n\n` +
       gemFile.slice(pluginSectionStart)
 
-    await writeFileAndCommit('Gemfile', newGemfile, 'Ajout de la gem ' + plugin)
+    await file.writeFileAndCommit(
+      'Gemfile',
+      newGemfile,
+      'Ajout de la gem ' + plugin,
+    )
   } catch (e) {
     const message = e instanceof Error ? e.message : 'erreur inconnue'
     logMessage(
@@ -214,7 +218,7 @@ export async function installPluginIfNecessary(plugin, version) {
     )
   }
 
-  await writeFileAndPushChanges(
+  await file.writeFileAndPushChanges(
     '_config.yml',
     newConfig,
     'Ajout du plugin ' + plugin,
@@ -243,14 +247,14 @@ const getCurrentRepoConfig = () => {
 
 /**
  * @param {string} css
- * @returns {ReturnType<typeof writeFileAndPushChanges>}
+ * @returns {ReturnType<typeof file.writeFileAndPushChanges>}
  */
-export function saveCustomCSS(css) {
-  store.mutations.setTheme(css)
-  store.state.buildStatus.setBuildingAndCheckStatusLater(10000)
-  return writeFileAndPushChanges(
+export function saveCustomCSS(css, localStore = store) {
+  localStore.mutations.setTheme(css)
+  localStore.state.buildStatus.setBuildingAndCheckStatusLater(10000)
+  return file.writeFileAndPushChanges(
     CUSTOM_CSS_PATH,
     css,
-    'mise à jour du ficher de styles custom',
+    'mise à jour du fichier de styles custom',
   )
 }

--- a/assets/scripts/actions/file.js
+++ b/assets/scripts/actions/file.js
@@ -10,20 +10,23 @@ import store from './../store.js'
  *
  * @returns {Promise<string>}
  */
-export const writeFileAndCommit = (fileName, content, commitMessage) => {
+export const writeFileAndCommit = async (
+  fileName,
+  content,
+  commitMessage,
+  localStore = store,
+) => {
   if (typeof commitMessage !== 'string' || commitMessage === '') {
     commitMessage = `Modification du fichier ${fileName}`
   }
-  const { gitAgent } = store.state
+  const { gitAgent } = localStore.state
 
   if (!gitAgent) {
     throw new TypeError('gitAgent is undefined')
   }
 
-  return gitAgent.writeFile(fileName, content).then(() => {
-    // @ts-ignore
-    return gitAgent.commit(commitMessage)
-  })
+  await gitAgent.writeFile(fileName, content)
+  return gitAgent.commit(commitMessage)
 }
 
 /**
@@ -33,20 +36,20 @@ export const writeFileAndCommit = (fileName, content, commitMessage) => {
  *
  * @returns {ReturnType<typeof GitAgent.prototype.safePush>}
  */
-export const writeFileAndPushChanges = (
+export const writeFileAndPushChanges = async (
   fileName,
   content,
   commitMessage = '',
+  localStore = store,
 ) => {
-  const { gitAgent } = store.state
+  const { gitAgent } = localStore.state
 
   if (!gitAgent) {
     throw new TypeError('gitAgent is undefined')
   }
 
-  return writeFileAndCommit(fileName, content, commitMessage).then(() =>
-    gitAgent.safePush(),
-  )
+  await writeFileAndCommit(fileName, content, commitMessage)
+  return gitAgent.safePush()
 }
 
 /**
@@ -55,8 +58,12 @@ export const writeFileAndPushChanges = (
  *
  * @returns {ReturnType<typeof GitAgent.prototype.commit>}
  */
-export const deleteFileAndCommit = (fileName, commitMessage = '') => {
-  const { gitAgent } = store.state
+export const deleteFileAndCommit = async (
+  fileName,
+  commitMessage = '',
+  localStore = store,
+) => {
+  const { gitAgent } = localStore.state
 
   if (!gitAgent) {
     throw new TypeError('gitAgent is undefined')
@@ -66,9 +73,8 @@ export const deleteFileAndCommit = (fileName, commitMessage = '') => {
     commitMessage = `Suppression du fichier ${fileName}`
   }
 
-  return gitAgent.removeFile(fileName).then(() => {
-    return gitAgent.commit(commitMessage)
-  })
+  await gitAgent.removeFile(fileName)
+  return gitAgent.commit(commitMessage)
 }
 
 /**
@@ -77,16 +83,19 @@ export const deleteFileAndCommit = (fileName, commitMessage = '') => {
  *
  * @returns {ReturnType<typeof GitAgent.prototype.safePush>}
  */
-export const deleteFileAndPushChanges = (fileName, commitMessage) => {
-  const { gitAgent } = store.state
+export const deleteFileAndPushChanges = (
+  fileName,
+  commitMessage,
+  localStore = store,
+) => {
+  const { gitAgent } = localStore.state
 
   if (!gitAgent) {
     throw new TypeError('gitAgent is undefined')
   }
 
-  return deleteFileAndCommit(fileName, commitMessage).then(() =>
-    gitAgent.safePush(),
-  )
+  deleteFileAndCommit(fileName, commitMessage, localStore)
+  return gitAgent.safePush()
 }
 
 export const file = {

--- a/assets/scripts/actions/file.js
+++ b/assets/scripts/actions/file.js
@@ -14,9 +14,9 @@ export const writeFileAndCommit = (fileName, content, commitMessage) => {
   if (typeof commitMessage !== 'string' || commitMessage === '') {
     commitMessage = `Modification du fichier ${fileName}`
   }
-  const {gitAgent} = store.state
+  const { gitAgent } = store.state
 
-  if(!gitAgent){
+  if (!gitAgent) {
     throw new TypeError('gitAgent is undefined')
   }
 
@@ -38,14 +38,15 @@ export const writeFileAndPushChanges = (
   content,
   commitMessage = '',
 ) => {
-  const {gitAgent} = store.state
+  const { gitAgent } = store.state
 
-  if(!gitAgent){
+  if (!gitAgent) {
     throw new TypeError('gitAgent is undefined')
   }
 
-  return writeFileAndCommit(fileName, content, commitMessage)
-    .then(() => gitAgent.safePush())
+  return writeFileAndCommit(fileName, content, commitMessage).then(() =>
+    gitAgent.safePush(),
+  )
 }
 
 /**
@@ -55,9 +56,9 @@ export const writeFileAndPushChanges = (
  * @returns {ReturnType<typeof GitAgent.prototype.commit>}
  */
 export const deleteFileAndCommit = (fileName, commitMessage = '') => {
-  const {gitAgent} = store.state
+  const { gitAgent } = store.state
 
-  if(!gitAgent){
+  if (!gitAgent) {
     throw new TypeError('gitAgent is undefined')
   }
 
@@ -77,12 +78,20 @@ export const deleteFileAndCommit = (fileName, commitMessage = '') => {
  * @returns {ReturnType<typeof GitAgent.prototype.safePush>}
  */
 export const deleteFileAndPushChanges = (fileName, commitMessage) => {
-  const {gitAgent} = store.state
+  const { gitAgent } = store.state
 
-  if(!gitAgent){
+  if (!gitAgent) {
     throw new TypeError('gitAgent is undefined')
   }
 
-  return deleteFileAndCommit(fileName, commitMessage)
-    .then(() => gitAgent.safePush())
+  return deleteFileAndCommit(fileName, commitMessage).then(() =>
+    gitAgent.safePush(),
+  )
+}
+
+export const file = {
+  deleteFileAndPushChanges,
+  deleteFileAndCommit,
+  writeFileAndCommit,
+  writeFileAndPushChanges,
 }

--- a/tests/actions/current-repository.test.js
+++ b/tests/actions/current-repository.test.js
@@ -1,51 +1,33 @@
 import '../setup.js'
-import { fakeStateWithOneSite } from '../fixtures.js'
-import {
-  saveCustomCSS
-} from '../../assets/scripts/actions/current-repository.js'
-import gitAgent from '../../assets/scripts/gitAgent.js'
-import store from '../../assets/scripts/store.js'
-
-throw 'Test désactivé parce que je ne sais pas stub gitAgent comme propriété de store.state'
-
-// Use a common sandbox for all tests so we can easily restore it after each test.
-const sandbox = sinon.createSandbox()
+import { file } from '../../assets/scripts/actions/file.js'
+import { saveCustomCSS } from '../../assets/scripts/actions/current-repository.js'
+import { CUSTOM_CSS_PATH } from '../../assets/scripts/config.js'
 
 describe('actions/current-repository.js', () => {
-  beforeEach(() => {
-    sandbox.stub(store, 'state').value(fakeStateWithOneSite)
-  })
-
-  afterEach(() => {
-    sandbox.restore()
-  })
-
   describe('saveCustomCSS', () => {
-    before(() => {
-      sandbox.stub(gitAgent, 'writeFile').resolves()
-      sandbox.stub(gitAgent, 'commit').resolves()
-      sandbox.stub(gitAgent, 'safePush').resolves()
-    })
-
     it('calls writeFile, commit and safePush', done => {
-      saveCustomCSS('body{ background: pink; }')
-        .then(() => {
-          expect(gitAgent.writeFile).to.have.been.calledWith(
-            store.state.currentRepository,
-            'assets/css/custom.css', 
-            'body{ background: pink; }'
-          )
-          expect(gitAgent.commit).to.have.been.calledWith(
-            store.state.currentRepository,
-            `mise à jour du ficher de styles custom`
-          )
-          expect(gitAgent.safePush).to.have.been.calledWith(
-            store.state.currentRepository
-          )
-          done()
-        })
-        .catch(e => done(e))
+      const fakeStore = {
+        mutations: {
+          setTheme: sinon.stub(),
+        },
+        state: {
+          buildStatus: {
+            setBuildingAndCheckStatusLater: sinon.stub(),
+          },
+        },
+      }
+      sinon.stub(file, 'writeFileAndPushChanges')
+      const css = 'body{ background: pink; }'
+
+      saveCustomCSS(css, fakeStore)
+
+      expect(file.writeFileAndPushChanges).to.have.been.calledWithExactly(
+        CUSTOM_CSS_PATH,
+        css,
+        'mise à jour du fichier de styles custom',
+      )
+
+      done()
     })
   })
-
 })

--- a/tests/actions/file.test.js
+++ b/tests/actions/file.test.js
@@ -9,8 +9,6 @@ import {
 import gitAgent from './../../assets/scripts/GitAgent.js'
 import store from './../../assets/scripts/store.js'
 
-throw 'Test désactivé parce que je ne sais pas stub gitAgent comme propriété de store.state'
-
 // Use a common sandbox for all tests so we can easily restore it after each test.
 const sandbox = sinon.createSandbox()
 

--- a/tests/actions/file.test.js
+++ b/tests/actions/file.test.js
@@ -22,96 +22,98 @@ describe('actions/file.js', () => {
   })
 
   describe('writeFileAndCommit', () => {
-    before(() => {
-      sandbox.stub(gitAgent, 'writeFile').resolves()
-      sandbox.stub(gitAgent, 'commit').resolves()
-    })
-
     it('calls writeFile and commit', done => {
-      writeFileAndCommit('test.js', 'Curiouser and curiouser!')
-        .then(() => {
-          expect(gitAgent.writeFile).to.have.been.calledWith(
-            store.state.currentRepository,
-            'test.js',
-            'Curiouser and curiouser!',
-          )
-          expect(gitAgent.commit).to.have.been.calledWith(
-            store.state.currentRepository,
-            'Modification du fichier test.js',
-          )
-          done()
-        })
-        .catch(e => done(e))
+      const fakeStore = {
+        state: {
+          gitAgent: {
+            writeFile: sinon.stub(),
+            commit: sinon.stub(),
+          },
+        },
+      }
+      writeFileAndCommit(
+        'test.js',
+        'Curiouser and curiouser!',
+        undefined,
+        fakeStore,
+      )
+      done()
+      expect(fakeStore.state.gitAgent.writeFile).to.have.been.calledWith(
+        'bla',
+        'test.js',
+        'Curiouser and curiouser!',
+      )
+      expect(faceStore.state.gitAgent.commit).to.have.been.calledWith(
+        'fanne',
+        'Modification du fichier test.js',
+      )
     })
   })
 
   describe('writeFileAndPushChanges', () => {
-    before(() => {
-      sandbox.stub(gitAgent, 'writeFile').resolves()
-      sandbox.stub(gitAgent, 'commit').resolves()
-      sandbox.stub(gitAgent, 'safePush').resolves()
-    })
-
     it('calls writeFile, commit and push', done => {
-      writeFileAndPushChanges('test.js', 'Curiouser and curiouser!')
-        .then(() => {
-          expect(gitAgent.writeFile).to.have.been.calledWith(
-            store.state.currentRepository,
-            'test.js',
-            'Curiouser and curiouser!',
-          )
-          expect(gitAgent.commit).to.have.been.calledWith(
-            store.state.currentRepository,
-            `Modification du fichier test.js`,
-          )
-          expect(gitAgent.safePush).to.have.been.calledWith(
-            store.state.currentRepository,
-          )
-          done()
-        })
-        .catch(e => done(e))
+      const fakeStore = {
+        state: {
+          gitAgent: {
+            removeFile: sinon.stub(),
+            commit: sinon.stub(),
+          },
+        },
+      }
+      writeFileAndPushChanges(
+        'test.js',
+        'Curiouser and curiouser!',
+        undefined,
+        fakeStore,
+      )
+      done()
+      expect(gitAgent.writeFile).to.have.been.calledWith(
+        store.state.currentRepository,
+        'test.js',
+        'Curiouser and curiouser!',
+      )
+      expect(gitAgent.commit).to.have.been.calledWith(
+        store.state.currentRepository,
+        `Modification du fichier test.js`,
+      )
+      expect(gitAgent.safePush).to.have.been.calledWith(
+        store.state.currentRepository,
+      )
     })
   })
 
   describe('deleteFileAndCommit', () => {
-    before(() => {
-      sandbox.stub(gitAgent, 'removeFile').resolves()
-      sandbox.stub(gitAgent, 'commit').resolves()
-    })
-
     it('calls removeFile and commit', done => {
-      deleteFileAndCommit('test.js')
-        .then(() => {
-          expect(gitAgent.removeFile).to.have.been.calledWith(
-            store.state.currentRepository,
-            'test.js',
-          )
-          expect(gitAgent.commit).to.have.been.calledWith(
-            store.state.currentRepository,
-            'Suppression du fichier test.js',
-          )
-          done()
-        })
-        .catch(e => done(e))
+      const fakeStore = {
+        state: {
+          gitAgent: {
+            removeFile: sinon.stub(),
+            commit: sinon.stub(),
+          },
+        },
+      }
+
+      deleteFileAndCommit('test.js', undefined, fakeStore)
+      done()
+      expect(fakeStore.state.gitAgent.removeFile).to.have.been.calledOnce
+      expect(fakeStore.state.gitAgent.commit).to.have.been.calledOnce
     })
   })
 
   describe('deleteFileAndPushChanges', () => {
-    before(() => {
-      sandbox.stub(gitAgent, 'removeFile').resolves()
-      sandbox.stub(gitAgent, 'commit').resolves()
-      sandbox.stub(gitAgent, 'safePush').resolves()
-    })
-
     it('calls removeFile and commit', done => {
-      deleteFileAndPushChanges('test.js')
-        .then(() => {
-          expect(gitAgent.safePush).to.have.been.calledWith(
-            store.state.currentRepository,
-          )
-          done()
-        })
-        .catch(e => done(e))
+      const fakeStore = {
+        state: {
+          gitAgent: {
+            removeFile: sinon.stub(),
+            safePush: sinon.stub(),
+            commit: sinon.stub(),
+          },
+        },
+      }
+      deleteFileAndPushChanges('test.js', undefined, fakeStore)
+      expect(fakeStore.state.gitAgent.safePush).to.have.been.calledOnce
+      done()
     })
   })
 })


### PR DESCRIPTION
Suppression des `throw` qui arrête l'exécution des tests.
Reprise de l'écriture des tests pour vérifier la dimension « passe plat » du code couvert aujourd'hui.
Mise en place d'injection de dépendance pour faciliter les tests.

C'est un début, il y a sans doute beaucoup à revoir sur l'injection de dépendance et sur la façon de faire les tests. Mais c'est un début :)