### PR TITLE
Sortir les types dans des fichiers différents

### DIFF
--- a/assets/scripts/types/atelier.js
+++ b/assets/scripts/types/atelier.js
@@ -1,0 +1,37 @@
+/**
+ * @typedef {Object} Page
+ * @property {string} path
+ * @property {string} title
+ * @property {string} [content]
+ * @property {boolean} [inMenu]
+ * @property {boolean} [blogIndex] Is this page the index of the blog section? Defaults to false.
+ * @property {number} index
+ */
+
+/**
+ * @typedef {Object} Article
+ * @property {string} path
+ * @property {string} title
+ * @property {string} [content]
+ */
+
+/**
+ * @typedef {Object} EditeurFile
+ * @property {string} fileName
+ * @property {string} content
+ * @property {string | undefined} previousContent
+ * @property {string} title
+ * @property {number} index
+ * @property {string | undefined} previousTitle
+ * @property {boolean} blogIndex
+ */
+
+/**
+ * @typedef {Object} FileContenu
+ * @property {string} path
+ * @property {string} title
+ * @property {string} content
+ * @property {number} index
+ * @property {boolean} inMenu
+ * @property {boolean} blogIndex
+ */

--- a/assets/scripts/types/git.js
+++ b/assets/scripts/types/git.js
@@ -1,21 +1,4 @@
 /**
- * @typedef {Object} Page
- * @property {string} path
- * @property {string} title
- * @property {string} [content]
- * @property {boolean} [inMenu]
- * @property {boolean} [blogIndex] Is this page the index of the blog section? Defaults to false.
- * @property {number} index
- */
-
-/**
- * @typedef {Object} Article
- * @property {string} path
- * @property {string} title
- * @property {string} [content]
- */
-
-/**
  * @typedef {Object} ScribouilliGitRepo
  * @property {string} repoId
  * @property {string} owner
@@ -33,6 +16,7 @@
  */
 
 /**
+ * @description On pense que ça correspond au build status de GitHub?
  * @typedef {"in_progress" | "success" | "error" | "not_public"} BuildStatus
  */
 
@@ -82,25 +66,4 @@
  * @property {string} name
  * @property {Object} owner
  * @property {string} owner.login
- */
-
-/**
- * @typedef {Object} EditeurFile
- * @property {string} fileName
- * @property {string} content
- * @property {string | undefined} previousContent
- * @property {string} title
- * @property {number} index
- * @property {string | undefined} previousTitle
- * @property {boolean} blogIndex
- */
-
-/**
- * @typedef {Object} FileContenu
- * @property {string} path
- * @property {string} title
- * @property {string} content
- * @property {number} index
- * @property {boolean} inMenu
- * @property {boolean} blogIndex
  */


### PR DESCRIPTION
On a voulu sortir les types dans des fichiers ts et mettre à jour TypeScript. Mais l'erreur `Type' is declared but its value is never read.` remonte souvent avec les imports jsdoc. C'est gênant avec l'usage de `tsc` avec le pre-commit hook. Ce bug TypeScript est en cours de résolution sur https://github.com/microsoft/TypeScript/issues/60908.

On a donc juste sorti les types dans des fichiers dédiés.