### PR TITLE
Fixe les imports de types

### DIFF
--- a/.github/workflows/qualite-de-code.yml
+++ b/.github/workflows/qualite-de-code.yml
@@ -1,0 +1,18 @@
+name: Build and Deploy
+on: [pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          npm pkg delete scripts.prepare
+          npm ci
+          npm run build
+          npm run test

--- a/assets/scripts/GitAgent.js
+++ b/assets/scripts/GitAgent.js
@@ -15,8 +15,6 @@ import FS from '@isomorphic-git/lightning-fs'
 import git from 'isomorphic-git'
 import http from 'isomorphic-git/http/web/index.js'
 
-import './types.js'
-
 const DEFAULT_CORS_PROXY_URL = 'https://cors.isomorphic-git.org'
 
 /** @typedef {import('isomorphic-git')} isomorphicGit */

--- a/assets/scripts/actions/setup.js
+++ b/assets/scripts/actions/setup.js
@@ -4,15 +4,14 @@ import page from 'page'
 
 import store from './../store.js'
 import ScribouilliGitRepo, {
-  makePublicRepositoryURL, makeRepoId,
+  makePublicRepositoryURL,
+  makeRepoId,
 } from './../scribouilliGitRepo.js'
 import { getOAuthServiceAPI } from './../oauth-services-api/index.js'
 import { makeAtelierListPageURL } from './../routes/urls.js'
 import { logMessage } from './../utils.js'
 import { setBaseUrlInConfigIfNecessary } from './current-repository.js'
 import GitAgent from '../GitAgent.js'
-
-import '../types.js'
 
 /** @typedef {import('isomorphic-git')} isomorphicGit */
 
@@ -57,11 +56,10 @@ export const waitOauthProvider = () => {
  * @returns {Promise<ReturnType<isomorphicGit["setConfig"]>>}
  */
 export const setupLocalRepository = async () => {
-  
   const login = await store.state.login
-  const {gitAgent, email} = store.state
+  const { gitAgent, email } = store.state
 
-  if(!gitAgent){
+  if (!gitAgent) {
     throw new TypeError('gitAgent is undefined')
   }
   if (!login) {
@@ -154,17 +152,18 @@ export const createRepositoryForCurrentAccount = async (repoName, template) => {
   return (
     getOAuthServiceAPI()
       .createDefaultRepository(scribouilliGitRepo, template)
-      .then(({remoteURL}) => {
-
+      .then(({ remoteURL }) => {
         const gitAgent = new GitAgent({
           repoId: makeRepoId(owner, escapedRepoName),
           remoteURL: remoteURL,
-          onMergeConflict : (/** @type {import("./../store.js").ResolutionOption[] | undefined} */ resolutionOptions) => {
+          onMergeConflict: (
+            /** @type {import("./../store.js").ResolutionOption[] | undefined} */ resolutionOptions,
+          ) => {
             store.mutations.setConflict(resolutionOptions)
           },
-          auth: getOAuthServiceAPI().getOauthUsernameAndPassword()
+          auth: getOAuthServiceAPI().getOauthUsernameAndPassword(),
         })
-      
+
         store.mutations.setGitAgent(gitAgent)
 
         // Il est nécessaire d'attendre que le repo soit prêt sur la remote

--- a/assets/scripts/components/screens/AfterOauthLogin.svelte
+++ b/assets/scripts/components/screens/AfterOauthLogin.svelte
@@ -1,7 +1,7 @@
 <script>
   import Skeleton from "./../Skeleton.svelte";
   import SiteCreationLoader from "./../loaders/SiteCreationLoader.svelte";
-  import './../../types.js'
+
   /** @type {Promise<GithubRepository[]|Void>} */
   export let currentUserReposP;
   /** @type {string} */

--- a/assets/scripts/components/screens/ArticleContenu.svelte
+++ b/assets/scripts/components/screens/ArticleContenu.svelte
@@ -1,6 +1,5 @@
 <script>
   import {makeAtelierListArticlesURL} from '../../routes/atelier-list-articles.js'
-  import './../../types.js'
 
   /** @type {Promise<EditeurFile>} */
   export let fileP;

--- a/assets/scripts/components/screens/CreateNewSite.svelte
+++ b/assets/scripts/components/screens/CreateNewSite.svelte
@@ -4,8 +4,6 @@
   import { createRepositoryForCurrentAccount } from "../../actions/setup.js";
   import { templates } from '../../config.js';
 
-  import '../../types.js'
-
   let name = "";
   let loading = false;
   let hasError = false

--- a/assets/scripts/components/screens/PageContenu.svelte
+++ b/assets/scripts/components/screens/PageContenu.svelte
@@ -1,6 +1,5 @@
 <script>
   import {makeAtelierListPageURL} from '../../routes/urls.js'
-  import './../../types.js'
 
   /** @type {Promise<EditeurFile>} */
   export let fileP;

--- a/assets/scripts/components/screens/ResolutionDesynchronisation.svelte
+++ b/assets/scripts/components/screens/ResolutionDesynchronisation.svelte
@@ -2,7 +2,6 @@
     import Skeleton from "../Skeleton.svelte";
     import {addConflictRemovalAndRedirectToResolution} from
     '../../actions/current-user.js'
-    import '../../types.js'
 
     /** @typedef {import("../../store.js").ScribouilliState} ScribouilliState */
 

--- a/assets/scripts/components/screens/Settings.svelte
+++ b/assets/scripts/components/screens/Settings.svelte
@@ -3,7 +3,6 @@
 
   import Skeleton from '../Skeleton.svelte'
   import { createEventDispatcher } from 'svelte'
-  import './../../types.js'
 
   const dispatch = createEventDispatcher()
 

--- a/assets/scripts/components/screens/intern/Editeur.svelte
+++ b/assets/scripts/components/screens/intern/Editeur.svelte
@@ -1,6 +1,4 @@
 <script>
-  import '../../../types.js'
-
   /** @type Promise<EditeurFile> */
   export let fileP
 

--- a/assets/scripts/components/screens/intern/ListContenu.svelte
+++ b/assets/scripts/components/screens/intern/ListContenu.svelte
@@ -2,7 +2,6 @@
   import store from '../../../store.js'
   import Skeleton from '../../Skeleton.svelte'
   import { makePageFrontMatter } from '../../../utils.js'
-  import './../../../types.js'
 
   /** @type {any} */
   export let buildStatus

--- a/assets/scripts/oauth-services-api/gitlab.js
+++ b/assets/scripts/oauth-services-api/gitlab.js
@@ -1,6 +1,5 @@
 //@ts-check
 
-import './../types.js'
 import GitAgent from '../GitAgent.js'
 
 /**

--- a/assets/scripts/oauth-services-api/index.js
+++ b/assets/scripts/oauth-services-api/index.js
@@ -3,8 +3,6 @@ import store from '../store.js'
 import GitHubAPI from './github.js'
 import GitlabAPI from './gitlab.js'
 
-import './../types.js'
-
 /**
  * @overlaod
  * @param {'github'} type
@@ -29,12 +27,11 @@ import './../types.js'
 const makeOAuthServiceAPI = ({ accessToken, origin }) => {
   const hostname = new URL(origin).hostname
 
-  if (hostname === 'github.com') 
-    return new GitHubAPI(accessToken)
+  if (hostname === 'github.com') return new GitHubAPI(accessToken)
   else {
     // assuming a gitlab instance
     return new GitlabAPI(accessToken, origin, () => {
-      if(!store.state.gitAgent){
+      if (!store.state.gitAgent) {
         throw new TypeError('store.state.gitAgent is undefined')
       }
       return store.state.gitAgent

--- a/assets/scripts/store.js
+++ b/assets/scripts/store.js
@@ -14,7 +14,6 @@ import Store from 'baredux'
 // DO NOT import x from 'remember' // do it in an action instead
 // DO NOT import x from './actions/*.js' // you're making an action, so add an action instead
 
-import './types.js'
 import GitAgent from './GitAgent.js'
 
 /** @typedef { {message: string, resolution: (...args: any[]) => Promise<any>} } ResolutionOption */


### PR DESCRIPTION
Fix https://github.com/Scribouilli/scribouilli/actions/runs/13286589515/job/37096579483#step:3:136

En séparant les types dans deux fichiers différents, j'ai cassé les imports. Ce que je n'avais pas testé my bad 😅J'ai donc ajouté dans cette PR, un fichier pour lancer rollup sur toutes les PRs et les tests afin qu'on puisse être averti lorsqu'on casse le build sur une PR.

Aussi, en creusant sur ces imports du fichier `./types.js`, je réalise qu'on n'en a pas besoin car l'import de ce fichier est géré dans le [`tsconfig`](https://github.com/Scribouilli/scribouilli/blob/principale/tsconfig.json#L2). J'ai donc retiré tous ces imports.