### PR TITLE
Fix get build status

### DIFF
--- a/assets/scripts/buildStatus.js
+++ b/assets/scripts/buildStatus.js
@@ -93,18 +93,22 @@ async function getBuildStatus(currentRepository, gitAgent) {
 
   const url = new URL(response.url)
 
-  if (response.redirected && url.hostname.endsWith('projects.gitlab.io')) {
+  if (
+    !response.ok &&
+    !isItStillCompiling(lastCommit) &&
+    url.hostname.endsWith('gitlab.io')
+  ) {
     // We handle the case where GitLab redirects to the login page
     // because the account is not verified.
     return 'needs_account_verification'
   }
 
-  if (!response.ok && isItStillCompiling(lastCommit)) {
-    return 'in_progress'
+  if (!response.ok && !isItStillCompiling(lastCommit)) {
+    return 'error'
   }
 
-  if (!response.ok) {
-    return 'error'
+  if (!response.ok && isItStillCompiling(lastCommit)) {
+    return 'in_progress'
   }
 
   html = await response.text()

--- a/assets/scripts/components/Header.svelte
+++ b/assets/scripts/components/Header.svelte
@@ -152,7 +152,7 @@
 {/if}
 
 {#if needsAccountVerification}
-  <section class="warning warning-public">
+  <section class="warning warning-center">
     <p class="centered"><span>⚠️</span> <strong>Attention..</strong></p>
 
     <p>
@@ -238,21 +238,6 @@
       strong {
         display: block;
       }
-    }
-
-    &-public {
-      span + strong {
-        font-size: 125%;
-      }
-
-      ol {
-        margin-left: 1rem;
-
-        li {
-          margin-bottom: 1rem;
-        }
-      }
-
     }
   }
 


### PR DESCRIPTION
Fix https://github.com/Scribouilli/scribouilli/issues/237 

Cette PR répare la gestion des différents cas pour `getBuildStatus` qu'on n'avait pas bien compris dans #243. 

De ce qu'on comprends avec https://github.com/Scribouilli/scribouilli/issues/237, on part donc du principe que : 
- si on dépasse le délai de 1 minute pour checker l'existence de la page et que c'est un site GitLab Pages qui renvoie une 404, on se dit que c'est un souci de compte GitLab non-vérifié. 
- si on dépasse le délai de 1 minute pour checker l'existence de la page et que ce n'est pas une page GitLab qui renvoie une 404, on considère que le statut de la page est en erreur,
- si on est toujours dans le délai de 1 minute, on considère qu'on est encore en train de builder le site.