### PR TITLE
Essai la configuration de isomorphic-git proxy de framasoft

### DIFF
--- a/assets/scripts/GitAgent.js
+++ b/assets/scripts/GitAgent.js
@@ -15,7 +15,7 @@ import FS from '@isomorphic-git/lightning-fs'
 import git from 'isomorphic-git'
 import http from 'isomorphic-git/http/web/index.js'
 
-const DEFAULT_CORS_PROXY_URL = 'https://cors.isomorphic-git.org'
+const DEFAULT_CORS_PROXY_URL = 'https://isomorphic-git.scribouilli.org'
 
 /** @typedef {import('isomorphic-git')} isomorphicGit */
 /** @typedef {import('isomorphic-git').GitAuth} GitAuth */


### PR DESCRIPTION
Mettre en place l'URL de proxy isomorphic-git proposé par Framasoft. 

close #259 