### PR TITLE
Fix issue #251: ajout code CSS

### DIFF
--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -358,3 +358,8 @@ ul.list-with-dot {
   padding-left: 1rem;
   list-style-type: disc;
 }
+
+ol {
+  padding-left: 1rem; 
+}
+


### PR DESCRIPTION
Le premier problème étant déjà résolu (en tout cas il fonctionnait avec les tests que j'ai fait), le seul souci qui reste est le deuxième (les numéros lors de l'énumération sortait du bloc). Il suffisait juste de rajouter un padding-left pour les ol dans le fichier CSS pour changer ce comportement :

Avant : 

<img width="1397" alt="avant modif" src="https://github.com/user-attachments/assets/f627694b-2156-4b4a-b769-e5344aadab6a" />



Après : 

<img width="1430" alt="apres modif" src="https://github.com/user-attachments/assets/9f7e54ae-145b-42bb-af93-1f576432a6a7" />
