### PR TITLE
Fix issue #251 et d'un probleme similaire avec les bullet points

### DIFF
--- a/assets/scripts/components/screens/intern/Editeur.svelte
+++ b/assets/scripts/components/screens/intern/Editeur.svelte
@@ -238,7 +238,7 @@
             {#if preview}
               <div class="preview">
                 <h4>Aperçu</h4>
-                <div>{@html preview}</div>
+                <div class="markdown-preview">{@html preview}</div>
               </div>
             {/if}
           </div>
@@ -379,4 +379,18 @@
       background-color: rgba(255, 255, 255, 0.4);
     }
   }
+  :global(.markdown-preview ul) {
+  list-style-type: disc !important;
+  padding-left: 1rem !important;
+}
+
+:global(.markdown-preview ol) {
+  list-style-type: decimal !important;
+  padding-left: 1rem !important;
+}
+
+:global(.markdown-preview li) {
+  margin-bottom: 0.5rem !important;
+}
+
 </style>


### PR DESCRIPTION
L'issue #251 du projet traitait 2 problèmes : 
- le premier : un souci avec la mise en forme de la taille des cases, en effet, la case contenu ne s'agrandissait pas quand la case review s'agrandit, or, avec mes tests, je me suis rendue compte que **ce problème a déjà été résolu**
- **le deuxième** : un problème dans les listes ordonnées, quand on en crée, on observe que dans l'aperçu les numéros de la liste sortent de la case aperçu, donc pour remédier à ce problème, j'ai ajouter dans le fichier CSS **un padding left à 1rem ce qui a réglé ce souci.**

J'ai aussi remarqué que pour les ul (liste non ordonnée), il y a un souci, en effet, q**uand on met des tirets "-", ces derniers ne s'affichent pas dans l'aperçu or ils le sont dans le site web généré** c'est pourquoi j'ai rajouté **un list-style:disc aux ul et en plus d'un padding-left:1rem** pour que ce soit bien dans la case aperçu et ne déborde pas.

avant ces modifications on avait : 
<img width="1397" alt="avant modif" src="https://github.com/user-attachments/assets/ffe65762-13b0-4bf6-868e-e70250479aad" />
<img width="1441" alt="Screenshot 2025-03-26 at 10 48 11" src="https://github.com/user-attachments/assets/c472688a-5e94-4c7c-abba-0acf9acc88dd" />
et après ces modifications on a : 
<img width="1454" alt="Screenshot 2025-03-26 at 11 32 07" src="https://github.com/user-attachments/assets/96428048-c1eb-4706-8fd8-d8ccd1af733f" />
<img width="1430" alt="apres modif" src="https://github.com/user-attachments/assets/26438cbb-b8fd-4533-a035-600444ea59e2" />

