### PR TITLE
Ajouter une barre d'outil markdown

### DIFF
--- a/assets/scripts/components/screens/intern/Editeur.svelte
+++ b/assets/scripts/components/screens/intern/Editeur.svelte
@@ -33,6 +33,8 @@
   import { writeFileAndCommit } from '../../../actions/file'
   import './../../../../styles/editeur-preview/framalibre.css'
 
+  import '@github/markdown-toolbar-element'
+
   /** @type {FileList} */
   let files
   // single-image selection
@@ -228,6 +230,21 @@
           <div class="content-preview">
             <div class="content">
               <label for="content">Contenu</label>
+              <markdown-toolbar for="content">
+  <md-bold>bold</md-bold>
+  <md-header>header</md-header>
+  <md-italic>italic</md-italic>
+  <md-quote>quote</md-quote>
+  <md-code>code</md-code>
+  <md-link>link</md-link>
+  <md-image>image</md-image>
+  <md-unordered-list>unordered-list</md-unordered-list>
+  <md-ordered-list>ordered-list</md-ordered-list>
+  <md-task-list>task-list</md-task-list>
+  <md-mention>mention</md-mention>
+  <md-ref>ref</md-ref>
+  <button data-md-button>Custom button</button>
+</markdown-toolbar>
               <textarea
                 bind:value={file.content}
                 id="content"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@github/markdown-toolbar-element": "^2.2.3",
         "@isomorphic-git/lightning-fs": "^4.6.0",
         "baredux": "github:DavidBruant/baredux#v1.0.8",
         "d3-fetch": "^3.0.1",
@@ -200,6 +201,12 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@github/markdown-toolbar-element": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.2.3.tgz",
+      "integrity": "sha512-AlquKGee+IWiAMYVB0xyHFZRMnu4n3X4HTvJHu79GiVJ1ojTukCWyxMlF5NMsecoLcBKsuBhx3QPv2vkE/zQ0A==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
@@ -6698,6 +6705,11 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
       "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
       "dev": true
+    },
+    "@github/markdown-toolbar-element": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.2.3.tgz",
+      "integrity": "sha512-AlquKGee+IWiAMYVB0xyHFZRMnu4n3X4HTvJHu79GiVJ1ojTukCWyxMlF5NMsecoLcBKsuBhx3QPv2vkE/zQ0A=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.13",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@github/markdown-toolbar-element": "^2.2.3",
     "@isomorphic-git/lightning-fs": "^4.6.0",
     "baredux": "github:DavidBruant/baredux#v1.0.8",
     "d3-fetch": "^3.0.1",


### PR DESCRIPTION
#303 

J'ai essayé d'ajouter `markdown-toolbar-element` mais ça ne semble pas fonctionner. J'ai dû oublier un truc.

<img width="656" height="276" alt="image" src="https://github.com/user-attachments/assets/8e9d65bb-79a3-4d64-98f9-922c67cff792" />
