### PR TITLE
Correction des pages cachées qui ré-apparaissent à l'édition

### DIFF
--- a/assets/scripts/actions/page.ts
+++ b/assets/scripts/actions/page.ts
@@ -64,6 +64,7 @@ export const createPage = (
   content: string,
   title: string,
   index: number,
+  inMenu: boolean = true
 ): ReturnType<typeof writeFileAndPushChanges> => {
   const { state } = store
   const fileName = makeFileNameFromTitle(title)
@@ -77,7 +78,7 @@ export const createPage = (
   store.mutations.setPages(newPages)
 
   const finalContent = `${
-    title ? makePageFrontMatter(title, index) + '\n' : ''
+    title ? makePageFrontMatter(title, index, inMenu) + '\n' : ''
   }${content} `
 
   return writeFileAndPushChanges(
@@ -92,6 +93,7 @@ export const updatePage = async (
   title: string,
   content: string,
   index: number,
+  inMenu: boolean,
   blogIndex: boolean,
 ): ReturnType<typeof writeFileAndPushChanges> => {
   const { gitAgent } = store.state
@@ -112,7 +114,7 @@ export const updatePage = async (
   }
 
   const finalContent = `${
-    title ? makePageFrontMatter(title, index, undefined, blogIndex) + '\n' : ''
+    title ? makePageFrontMatter(title, index, inMenu, blogIndex) + '\n' : ''
   }${content} `
 
   return writeFileAndPushChanges(

--- a/assets/scripts/components/screens/intern/Editeur.svelte
+++ b/assets/scripts/components/screens/intern/Editeur.svelte
@@ -63,6 +63,7 @@
   // parent component should be responsible for awaiting the promise and
   // displaying a loading screen.
   fileP.then(_file => {
+    console.log('fileP', _file)
     file = _file
   })
 

--- a/assets/scripts/routes/atelier-pages.ts
+++ b/assets/scripts/routes/atelier-pages.ts
@@ -51,7 +51,8 @@ const makeMapStateToProps =
       }
 
       try {
-        await updatePage(fileName, title, content, index, blogIndex)
+        throw `On a besoin de savoir quelle était la valeur de inMenu pour la fournir`
+        await updatePage(fileName, title, content, index, inMenu, blogIndex)
         setBuildingAndCheckStatusLater(state.currentRepository, state.gitAgent)
         page(makeAtelierListPageURL(state.currentRepository))
       } catch (msg: any) {

--- a/assets/scripts/utils.ts
+++ b/assets/scripts/utils.ts
@@ -59,7 +59,7 @@ export function makeArticleFileName(title: string, date: Date): string {
 export function makePageFrontMatter(
   title: string,
   index: number | null = 1,
-  inMenu: boolean = true,
+  inMenu: boolean, // this function is too low-level to assign a default to inMenu
   blogIndex?: boolean,
 ): string {
   return [


### PR DESCRIPTION
Fixes https://github.com/Scribouilli/scribouilli/issues/311

Pour le moment, ce n'est que le début

Le cœur du problème est que l'on ne préserve pas `inMenu` lors du changement de contenu d'un fichier

En creusant, j'ai réalisé que ça vient d'un mismatch entre les types `Page` et `EditeurFile`. Il serait bon que ces types partagent quelque chose plutôt que d'être complètement séparés

C'est + de taf que prévu de corriger ce bug, donc je me suis arrêtée là pour le moment